### PR TITLE
Reject requests with unsupported methods

### DIFF
--- a/example/httpMethods/app/test/src/ExampleTests.scala
+++ b/example/httpMethods/app/test/src/ExampleTests.scala
@@ -20,6 +20,7 @@ object ExampleTests extends TestSuite{
     test("HttpMethods") - withServer(HttpMethods){ host =>
       requests.post(s"$host/login").text() ==> "do_the_login"
       requests.get(s"$host/login").text() ==> "show_the_login_form"
+      requests.put(s"$host/login", check = false).statusCode ==> 405
       requests.delete(s"$host/session").text() ==> "delete_the_session"
       requests.get.copy(verb="secretmethod")(s"$host/session").text() ==> "security_by_obscurity"
     }


### PR DESCRIPTION
Currently, such methods lead to a match error in the routeTrie
lookup. This exception is printed, but since undertow defaults to
responding with 200, the effect is that requests with invalid methods
always return a successful response code.

The changes here modify this behavior to respond with a 405 if the
dispatch trie cannot be found in the method map.