### PR TITLE
Use ctx.bytes rather than getting the InputStream directly 

### DIFF
--- a/cask/src/cask/endpoints/JsonEndpoint.scala
+++ b/cask/src/cask/endpoints/JsonEndpoint.scala
@@ -50,9 +50,7 @@ class postJson(val path: String, override val subpath: Boolean = false)
     val obj = for{
       str <-
         try {
-          val boas = new ByteArrayOutputStream()
-          Util.transferTo(ctx.exchange.getInputStream, boas)
-          Right(new String(boas.toByteArray))
+          Right(new String(ctx.bytes))
         }
         catch{case e: Throwable => Left(cask.model.Response(
           "Unable to deserialize input JSON text: " + e + "\n" + Util.stackTraceString(e),


### PR DESCRIPTION
Use ctx.bytes rather than getting the InputStream directly so that the contents of the InputStream are cached in the Request object. Right now if a Decorator tries to access the request body via the InputStream the InputStream will then be empty for the postJson decorator. Therefore, postJson should use the bytes field of Request so if an upstream Decorator also accesses the bytes field the value will be cached.