### PR TITLE
Case-insensitive comparison of the "Upgrade" request header

### DIFF
--- a/cask/src/cask/main/Main.scala
+++ b/cask/src/cask/main/Main.scala
@@ -81,7 +81,7 @@ object Main{
                       (implicit log: Logger) extends HttpHandler() {
     def handleRequest(exchange: HttpServerExchange): Unit = try {
       //        println("Handling Request: " + exchange.getRequestPath)
-      val (effectiveMethod, runner) = if (exchange.getRequestHeaders.getFirst("Upgrade") == "websocket") {
+      val (effectiveMethod, runner) = if ("websocket".equalsIgnoreCase(exchange.getRequestHeaders.getFirst("Upgrade"))) {
         Tuple2(
           "websocket",
           (r: Any) =>


### PR DESCRIPTION
This PR modifies the "Upgrade" header check in `DefaultHandler.handleRequest` by using a case-insensitive comparison, as per the WebSocket RFC.
Sorry for the Yoda condition... it seems that Undertow's `HeaderMap.getFirst()` can return null.

Fixes #77