### PR TITLE
Add `cask.QueryParams` type to allow route methods to take arbitrary query parameters

### DIFF
--- a/cask/src-3/cask/router/Macros.scala
+++ b/cask/src-3/cask/router/Macros.scala
@@ -264,12 +264,12 @@ object Macros {
                 Runtime.makeReadCall(
                   args,
                   ctx,
-                  (sig.default match {
+                  sig.default match {
                     case None => None
                     case Some(getter) =>
                       val value = getter.asInstanceOf[Cls => Any](clazz)
                       Some(value)
-                  }),
+                  },
                   sig
                 )
               }

--- a/cask/src/cask/endpoints/WebEndpoints.scala
+++ b/cask/src/cask/endpoints/WebEndpoints.scala
@@ -28,23 +28,32 @@ object WebEndpoint{
     b.result()
   }
 }
-class get(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
+class get(val path: String,
+          override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("get")
 }
-class post(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
+class post(val path: String,
+           override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("post")
 }
-class put(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
+class put(val path: String,
+          override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("put")
 }
-class patch(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
+class patch(val path: String,
+            override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("patch")
 }
-class delete(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
+class delete(val path: String,
+             override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("delete")
 }
-class route(val path: String, val methods: Seq[String], override val subpath: Boolean = false) extends WebEndpoint
-class options(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
+class route(val path: String,
+            val methods: Seq[String],
+            override val subpath: Boolean = false) extends WebEndpoint
+
+class options(val path: String,
+              override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("options")
 }
 
@@ -54,6 +63,15 @@ abstract class QueryParamReader[T]
   def read(ctx: cask.model.Request, label: String, v: Seq[String]): T
 }
 object QueryParamReader{
+  implicit object QueryParams extends QueryParamReader[cask.model.QueryParams]{
+    def arity: Int = 0
+
+    override def unknownQueryParams = true
+    def read(ctx: cask.model.Request, label: String, v: Seq[String]) = {
+      cask.model.QueryParams(ctx.queryParams)
+    }
+
+  }
   class SimpleParam[T](f: String => T) extends QueryParamReader[T]{
     def arity = 1
     def read(ctx: cask.model.Request, label: String, v: Seq[String]): T = f(v.head)

--- a/cask/src/cask/endpoints/WebEndpoints.scala
+++ b/cask/src/cask/endpoints/WebEndpoints.scala
@@ -28,29 +28,22 @@ object WebEndpoint{
     b.result()
   }
 }
-class get(val path: String,
-          override val subpath: Boolean = false) extends WebEndpoint{
+class get(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("get")
 }
-class post(val path: String,
-           override val subpath: Boolean = false) extends WebEndpoint{
+class post(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("post")
 }
-class put(val path: String,
-          override val subpath: Boolean = false) extends WebEndpoint{
+class put(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("put")
 }
-class patch(val path: String,
-            override val subpath: Boolean = false) extends WebEndpoint{
+class patch(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("patch")
 }
-class delete(val path: String,
-             override val subpath: Boolean = false) extends WebEndpoint{
+class delete(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("delete")
 }
-class route(val path: String,
-            val methods: Seq[String],
-            override val subpath: Boolean = false) extends WebEndpoint
+class route(val path: String, val methods: Seq[String], override val subpath: Boolean = false) extends WebEndpoint
 
 class options(val path: String,
               override val subpath: Boolean = false) extends WebEndpoint{

--- a/cask/src/cask/endpoints/WebEndpoints.scala
+++ b/cask/src/cask/endpoints/WebEndpoints.scala
@@ -45,8 +45,7 @@ class delete(val path: String, override val subpath: Boolean = false) extends We
 }
 class route(val path: String, val methods: Seq[String], override val subpath: Boolean = false) extends WebEndpoint
 
-class options(val path: String,
-              override val subpath: Boolean = false) extends WebEndpoint{
+class options(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("options")
 }
 

--- a/cask/src/cask/model/Params.scala
+++ b/cask/src/cask/model/Params.scala
@@ -6,6 +6,8 @@ import cask.internal.Util
 import io.undertow.server.HttpServerExchange
 import io.undertow.server.handlers.CookieImpl
 
+case class QueryParams(value: Map[String, collection.Seq[String]])
+
 case class Request(exchange: HttpServerExchange, remainingPathSegments: Seq[String])
 extends geny.ByteData with geny.Readable {
   import collection.JavaConverters._

--- a/cask/src/cask/package.scala
+++ b/cask/src/cask/package.scala
@@ -18,6 +18,8 @@ package object cask {
   val Cookie = model.Cookie
   type Request = model.Request
   val Request = model.Request
+  type QueryParams = model.QueryParams
+  val QueryParams = model.QueryParams
 
   // endpoints
   type websocket = endpoints.websocket

--- a/cask/src/cask/router/EntryPoint.scala
+++ b/cask/src/cask/router/EntryPoint.scala
@@ -33,12 +33,13 @@ case class EntryPoint[T, C](name: String,
     for(k <- firstArgs.keys) {
       if (!paramLists.head.contains(k)) {
         val as = firstArgs(k)
-        if (as.reads.arity != 0 && as.default.isEmpty) missing.append(as)
+        if (as.reads.arity > 0 && as.default.isEmpty) missing.append(as)
       }
     }
 
-    if (missing.nonEmpty || unknown.nonEmpty) Result.Error.MismatchedArguments(missing.toSeq, unknown.toSeq)
-    else {
+    if (missing.nonEmpty || (!argSignatures.exists(_.exists(_.reads.unknownQueryParams)) && unknown.nonEmpty)) {
+      Result.Error.MismatchedArguments(missing.toSeq, unknown.toSeq)
+    } else {
       try invoke0(
         target,
         ctx,

--- a/cask/src/cask/router/Misc.scala
+++ b/cask/src/cask/router/Misc.scala
@@ -19,5 +19,6 @@ case class ArgSig[I, -T, +V, -C](name: String,
 
 trait ArgReader[I, +T, -C]{
   def arity: Int
+  def unknownQueryParams: Boolean = false
   def read(ctx: C, label: String, input: I): T
 }

--- a/docs/pages/1 - Cask: a Scala HTTP micro-framework.md
+++ b/docs/pages/1 - Cask: a Scala HTTP micro-framework.md
@@ -139,16 +139,21 @@ $$$variableRoutes
 
 You can bind variables to endpoints by declaring them as parameters: these are
 either taken from a path-segment matcher of the same name (e.g. `postId` above),
-or from query-parameters of the same name (e.g. `param` above). You can make `param` take
+or from query-parameters of the same name (e.g. `param` above). You can make your route take
 
 * `param: String` to match `?param=hello`
-* `param: Int` for `?param=123`
+* `param: Int` for `?param=123`. Other valid types include `Boolean`, `Byte`, `Short`, `Long`, 
+  `Float`, `Double`
 * `param: Option[T] = None` or `param: String = "DEFAULT VALUE"` for cases where the
   `?param=hello` is optional.
 * `param: Seq[T]` for repeated params such as `?param=hello&param=world` with at 
   least one value
 * `param: Seq[T] = Nil` for repeated params such as `?param=hello&param=world` allowing
   zero values
+* `queryParams: cask.QueryParams` if you want your route to be able to handle arbitrary
+  query params without needing to list them out as separate arguments
+* `request: cask.Request` which provides lower level access to the things that the HTTP
+  request provides
 
 If you need to capture the entire sub-path of the request, you can set the flag
 `subpath=true` and ask for a `request: cask.Request` (the name of the param doesn't

--- a/docs/pages/1 - Cask: a Scala HTTP micro-framework.md
+++ b/docs/pages/1 - Cask: a Scala HTTP micro-framework.md
@@ -139,10 +139,16 @@ $$$variableRoutes
 
 You can bind variables to endpoints by declaring them as parameters: these are
 either taken from a path-segment matcher of the same name (e.g. `postId` above),
-or from query-parameters of the same name (e.g. `param` above). You can make
-`param` take a `: String` to match `?param=hello`, an `: Int` for `?param=123` a
-`Seq[T]` (as above) for repeated params such as `?param=hello&param=world`, or
-`: Option[T]` for cases where the `?param=hello` is optional.
+or from query-parameters of the same name (e.g. `param` above). You can make `param` take
+
+* `param: String` to match `?param=hello`
+* `param: Int` for `?param=123`
+* `param: Option[T] = None` or `param: String = "DEFAULT VALUE"` for cases where the
+  `?param=hello` is optional.
+* `param: Seq[T]` for repeated params such as `?param=hello&param=world` with at 
+  least one value
+* `param: Seq[T] = Nil` for repeated params such as `?param=hello&param=world` allowing
+  zero values
 
 If you need to capture the entire sub-path of the request, you can set the flag
 `subpath=true` and ask for a `request: cask.Request` (the name of the param doesn't

--- a/example/variableRoutes/app/src/VariableRoutes.scala
+++ b/example/variableRoutes/app/src/VariableRoutes.scala
@@ -6,7 +6,27 @@ object VariableRoutes extends cask.MainRoutes{
   }
 
   @cask.get("/post/:postId")
-  def showPost(postId: Int, param: Seq[String]) = {
+  def showPost(postId: Int, param: String) = { // Mandatory query param
+    s"Post $postId $param"
+  }
+
+  @cask.get("/post2/:postId") // Optional query param
+  def showPostOptional(postId: Int, param: Option[String] = None) = {
+    s"Post $postId $param"
+  }
+
+  @cask.get("/post3/:postId") // Optional query param with default
+  def showPostDefault(postId: Int, param: String = "DEFAULT VALUE") = { 
+    s"Post $postId $param"
+  }
+
+  @cask.get("/post4/:postId") // 1-or-more query param
+  def showPostSeq(postId: Int, param: Seq[String]) = {
+    s"Post $postId $param"
+  }
+
+  @cask.get("/post5/:postId") // 0-or-more query param
+  def showPostOptionalSeq(postId: Int, param: Seq[String] = Nil) = {
     s"Post $postId $param"
   }
 

--- a/example/variableRoutes/app/src/VariableRoutes.scala
+++ b/example/variableRoutes/app/src/VariableRoutes.scala
@@ -1,42 +1,42 @@
 package app
 object VariableRoutes extends cask.MainRoutes{
   @cask.get("/user/:userName")
-  def showUserProfile(userName: String) = {
+  def getUserProfile(userName: String) = {
     s"User $userName"
   }
 
-  @cask.get("/post/:postId")
-  def showPost(postId: Int, param: String) = { // Mandatory query param
-    s"Post $postId $param"
+  @cask.get("/article/:articleId")
+  def getArticle(articleId: Int, param: String) = { // Mandatory query param
+    s"Article $articleId $param"
   }
 
-  @cask.get("/post2/:postId") // Optional query param
-  def showPostOptional(postId: Int, param: Option[String] = None) = {
-    s"Post $postId $param"
+  @cask.get("/article2/:articleId") // Optional query param
+  def getArticleOptional(articleId: Int, param: Option[String] = None) = {
+    s"Article $articleId $param"
   }
 
-  @cask.get("/post3/:postId") // Optional query param with default
-  def showPostDefault(postId: Int, param: String = "DEFAULT VALUE") = { 
-    s"Post $postId $param"
+  @cask.get("/article3/:articleId") // Optional query param with default
+  def getArticleDefault(articleId: Int, param: String = "DEFAULT VALUE") = { 
+    s"Article $articleId $param"
   }
 
-  @cask.get("/post4/:postId") // 1-or-more query param
-  def showPostSeq(postId: Int, param: Seq[String]) = {
-    s"Post $postId $param"
+  @cask.get("/article4/:articleId") // 1-or-more query param
+  def getArticleSeq(articleId: Int, param: Seq[String]) = {
+    s"Article $articleId $param"
   }
 
-  @cask.get("/post5/:postId") // 0-or-more query param
-  def showPostOptionalSeq(postId: Int, param: Seq[String] = Nil) = {
-    s"Post $postId $param"
+  @cask.get("/article5/:articleId") // 0-or-more query param
+  def getArticleOptionalSeq(articleId: Int, param: Seq[String] = Nil) = {
+    s"Article $articleId $param"
   }
 
   @cask.get("/path", subpath = true)
-  def showSubpath(request: cask.Request) = {
+  def getSubpath(request: cask.Request) = {
     s"Subpath ${request.remainingPathSegments}"
   }
 
   @cask.post("/path", subpath = true)
-  def postShowSubpath(request: cask.Request) = {
+  def articlePostSubpath(request: cask.Request) = {
     s"POST Subpath ${request.remainingPathSegments}"
   }
 

--- a/example/variableRoutes/app/src/VariableRoutes.scala
+++ b/example/variableRoutes/app/src/VariableRoutes.scala
@@ -16,7 +16,7 @@ object VariableRoutes extends cask.MainRoutes{
   }
 
   @cask.get("/article3/:articleId") // Optional query param with default
-  def getArticleDefault(articleId: Int, param: String = "DEFAULT VALUE") = { 
+  def getArticleDefault(articleId: Int, param: String = "DEFAULT VALUE") = {
     s"Article $articleId $param"
   }
 
@@ -28,6 +28,11 @@ object VariableRoutes extends cask.MainRoutes{
   @cask.get("/article5/:articleId") // 0-or-more query param
   def getArticleOptionalSeq(articleId: Int, param: Seq[String] = Nil) = {
     s"Article $articleId $param"
+  }
+
+  @cask.get("/user2/:userName") // allow unknown query params
+  def getUserProfileAllowUnknown(userName: String, queryParams: cask.QueryParams) = {
+    s"User $userName " + queryParams.value
   }
 
   @cask.get("/path", subpath = true)

--- a/example/variableRoutes/app/src/VariableRoutes.scala
+++ b/example/variableRoutes/app/src/VariableRoutes.scala
@@ -36,7 +36,7 @@ object VariableRoutes extends cask.MainRoutes{
   }
 
   @cask.post("/path", subpath = true)
-  def articlePostSubpath(request: cask.Request) = {
+  def postArticleSubpath(request: cask.Request) = {
     s"POST Subpath ${request.remainingPathSegments}"
   }
 

--- a/example/variableRoutes/app/test/src/ExampleTests.scala
+++ b/example/variableRoutes/app/test/src/ExampleTests.scala
@@ -27,68 +27,68 @@ object ExampleTests extends TestSuite{
 
 
       assert(
-        requests.get(s"$host/post/123?param=xyz").text() ==
-          "Post 123 xyz"
+        requests.get(s"$host/article/123?param=xyz").text() ==
+          "Article 123 xyz"
       )
 
-      requests.get(s"$host/post/123", check = false).text() ==>
+      requests.get(s"$host/article/123", check = false).text() ==>
         """Missing argument: (param: String)
           |
           |Arguments provided did not match expected signature:
           |
-          |showPost
-          |  postId  Int
+          |getArticle
+          |  articleId  Int
           |  param  String
           |
           |""".stripMargin
 
       assert(
-        requests.get(s"$host/post2/123?param=xyz").text() ==
-          "Post 123 Some(xyz)"
+        requests.get(s"$host/article2/123?param=xyz").text() ==
+          "Article 123 Some(xyz)"
       )
 
       assert(
-        requests.get(s"$host/post2/123").text() ==
-          "Post 123 None"
+        requests.get(s"$host/article2/123").text() ==
+          "Article 123 None"
       )
 
       assert(
-        requests.get(s"$host/post3/123?param=xyz").text() ==
-          "Post 123 xyz"
+        requests.get(s"$host/article3/123?param=xyz").text() ==
+          "Article 123 xyz"
       )
 
       assert(
-        requests.get(s"$host/post3/123").text() ==
-          "Post 123 DEFAULT VALUE"
+        requests.get(s"$host/article3/123").text() ==
+          "Article 123 DEFAULT VALUE"
       )
 
 
       assert(
-        requests.get(s"$host/post4/123?param=xyz&param=abc").text() ==
-          "Post 123 ArraySeq(xyz, abc)" ||
-        requests.get(s"$host/post4/123?param=xyz&param=abc").text() ==
-          "Post 123 ArrayBuffer(xyz, abc)"
+        requests.get(s"$host/article4/123?param=xyz&param=abc").text() ==
+          "Article 123 ArraySeq(xyz, abc)" ||
+        requests.get(s"$host/article4/123?param=xyz&param=abc").text() ==
+          "Article 123 ArrayBuffer(xyz, abc)"
       )
 
-      requests.get(s"$host/post4/123", check = false).text() ==>
+      requests.get(s"$host/article4/123", check = false).text() ==>
         """Missing argument: (param: Seq[String])
           |
           |Arguments provided did not match expected signature:
           |
-          |showPostSeq
-          |  postId  Int
+          |getArticleSeq
+          |  articleId  Int
           |  param  Seq[String]
           |
           |""".stripMargin
 
       assert(
-        requests.get(s"$host/post5/123?param=xyz&param=abc").text() ==
-          "Post 123 ArraySeq(xyz, abc)" ||
-        requests.get(s"$host/post5/123?param=xyz&param=abc").text() ==
-          "Post 123 ArrayBuffer(xyz, abc)"
+        requests.get(s"$host/article5/123?param=xyz&param=abc").text() ==
+          "Article 123 ArraySeq(xyz, abc)" ||
+        requests.get(s"$host/article5/123?param=xyz&param=abc").text() ==
+          "Article 123 ArrayBuffer(xyz, abc)"
       )
       assert(
-        requests.get(s"$host/post5/123").text() == "Post 123 List()"
+        requests.get(s"$host/article5/123").text() == "Article 123 List()"
       )
 
       requests.get(s"$host/path/one/two/three").text() ==>

--- a/example/variableRoutes/app/test/src/ExampleTests.scala
+++ b/example/variableRoutes/app/test/src/ExampleTests.scala
@@ -96,6 +96,25 @@ object ExampleTests extends TestSuite{
 
       requests.post(s"$host/path/one/two/three").text() ==>
         "POST Subpath List(one, two, three)"
+
+      requests.get(s"$host/user/lihaoyi?unknown1=123&unknown2=abc", check = false).text() ==>
+        """Unknown arguments: "unknown1" "unknown2"
+          |
+          |Arguments provided did not match expected signature:
+          |
+          |getUserProfile
+          |  userName  String
+          |
+          |""".stripMargin
+
+
+      assert(
+        requests.get(s"$host/user2/lihaoyi?unknown1=123&unknown2=abc", check = false).text() ==
+          "User lihaoyi Map(unknown1 -> ArrayBuffer(123), unknown2 -> ArrayBuffer(abc))" ||
+        requests.get(s"$host/user2/lihaoyi?unknown1=123&unknown2=abc", check = false).text() ==
+          "User lihaoyi Map(unknown1 -> ArraySeq(123), unknown2 -> ArraySeq(abc))"
+      )
+
     }
 
   }

--- a/example/variableRoutes/app/test/src/ExampleTests.scala
+++ b/example/variableRoutes/app/test/src/ExampleTests.scala
@@ -63,11 +63,10 @@ object ExampleTests extends TestSuite{
       )
 
 
+      val res1 = requests.get(s"$host/article4/123?param=xyz&param=abc").text()
       assert(
-        requests.get(s"$host/article4/123?param=xyz&param=abc").text() ==
-          "Article 123 ArraySeq(xyz, abc)" ||
-        requests.get(s"$host/article4/123?param=xyz&param=abc").text() ==
-          "Article 123 ArrayBuffer(xyz, abc)"
+        res1 == "Article 123 ArraySeq(xyz, abc)" ||
+        res1 == "Article 123 ArrayBuffer(xyz, abc)"
       )
 
       requests.get(s"$host/article4/123", check = false).text() ==>
@@ -81,11 +80,10 @@ object ExampleTests extends TestSuite{
           |
           |""".stripMargin
 
+      val res2 = requests.get(s"$host/article5/123?param=xyz&param=abc").text()
       assert(
-        requests.get(s"$host/article5/123?param=xyz&param=abc").text() ==
-          "Article 123 ArraySeq(xyz, abc)" ||
-        requests.get(s"$host/article5/123?param=xyz&param=abc").text() ==
-          "Article 123 ArrayBuffer(xyz, abc)"
+        res2 == "Article 123 ArraySeq(xyz, abc)" ||
+        res2 == "Article 123 ArrayBuffer(xyz, abc)"
       )
       assert(
         requests.get(s"$host/article5/123").text() == "Article 123 List()"
@@ -108,11 +106,10 @@ object ExampleTests extends TestSuite{
           |""".stripMargin
 
 
+      val res3 = requests.get(s"$host/user2/lihaoyi?unknown1=123&unknown2=abc", check = false).text()
       assert(
-        requests.get(s"$host/user2/lihaoyi?unknown1=123&unknown2=abc", check = false).text() ==
-          "User lihaoyi Map(unknown1 -> ArrayBuffer(123), unknown2 -> ArrayBuffer(abc))" ||
-        requests.get(s"$host/user2/lihaoyi?unknown1=123&unknown2=abc", check = false).text() ==
-          "User lihaoyi Map(unknown1 -> ArraySeq(123), unknown2 -> ArraySeq(abc))"
+        res3 == "User lihaoyi Map(unknown1 -> WrappedArray(123), unknown2 -> WrappedArray(abc))" ||
+        res3 == "User lihaoyi Map(unknown1 -> ArraySeq(123), unknown2 -> ArraySeq(abc))"
       )
 
     }

--- a/example/variableRoutes/app/test/src/ExampleTests.scala
+++ b/example/variableRoutes/app/test/src/ExampleTests.scala
@@ -108,6 +108,7 @@ object ExampleTests extends TestSuite{
 
       val res3 = requests.get(s"$host/user2/lihaoyi?unknown1=123&unknown2=abc", check = false).text()
       assert(
+        res3 == "User lihaoyi Map(unknown1 -> ArrayBuffer(123), unknown2 -> ArrayBuffer(abc))" ||
         res3 == "User lihaoyi Map(unknown1 -> WrappedArray(123), unknown2 -> WrappedArray(abc))" ||
         res3 == "User lihaoyi Map(unknown1 -> ArraySeq(123), unknown2 -> ArraySeq(abc))"
       )

--- a/example/variableRoutes/app/test/src/ExampleTests.scala
+++ b/example/variableRoutes/app/test/src/ExampleTests.scala
@@ -27,22 +27,69 @@ object ExampleTests extends TestSuite{
 
 
       assert(
-        requests.get(s"$host/post/123?param=xyz&param=abc").text() ==
-          "Post 123 ArraySeq(xyz, abc)" ||
-        requests.get(s"$host/post/123?param=xyz&param=abc").text() ==
-          "Post 123 ArrayBuffer(xyz, abc)"
+        requests.get(s"$host/post/123?param=xyz").text() ==
+          "Post 123 xyz"
       )
 
       requests.get(s"$host/post/123", check = false).text() ==>
-        """Missing argument: (param: Seq[String])
+        """Missing argument: (param: String)
           |
           |Arguments provided did not match expected signature:
           |
           |showPost
           |  postId  Int
+          |  param  String
+          |
+          |""".stripMargin
+
+      assert(
+        requests.get(s"$host/post2/123?param=xyz").text() ==
+          "Post 123 Some(xyz)"
+      )
+
+      assert(
+        requests.get(s"$host/post2/123").text() ==
+          "Post 123 None"
+      )
+
+      assert(
+        requests.get(s"$host/post3/123?param=xyz").text() ==
+          "Post 123 xyz"
+      )
+
+      assert(
+        requests.get(s"$host/post3/123").text() ==
+          "Post 123 DEFAULT VALUE"
+      )
+
+
+      assert(
+        requests.get(s"$host/post4/123?param=xyz&param=abc").text() ==
+          "Post 123 ArraySeq(xyz, abc)" ||
+        requests.get(s"$host/post4/123?param=xyz&param=abc").text() ==
+          "Post 123 ArrayBuffer(xyz, abc)"
+      )
+
+      requests.get(s"$host/post4/123", check = false).text() ==>
+        """Missing argument: (param: Seq[String])
+          |
+          |Arguments provided did not match expected signature:
+          |
+          |showPostSeq
+          |  postId  Int
           |  param  Seq[String]
           |
           |""".stripMargin
+
+      assert(
+        requests.get(s"$host/post5/123?param=xyz&param=abc").text() ==
+          "Post 123 ArraySeq(xyz, abc)" ||
+        requests.get(s"$host/post5/123?param=xyz&param=abc").text() ==
+          "Post 123 ArrayBuffer(xyz, abc)"
+      )
+      assert(
+        requests.get(s"$host/post5/123").text() == "Post 123 List()"
+      )
 
       requests.get(s"$host/path/one/two/three").text() ==>
         "Subpath List(one, two, three)"


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/cask/issues/99