### PR TITLE
Minor docs update. Update badges.

### DIFF
--- a/docs/pages/1 - Cask: a Scala HTTP micro-framework.md
+++ b/docs/pages/1 - Cask: a Scala HTTP micro-framework.md
@@ -1,14 +1,11 @@
 
 
-[![Build Status][travis-badge]][travis-link]
-[![Gitter Chat][gitter-badge]][gitter-link]
+[![Discord Chat][discord-badge]][discord-link]
 [![Patreon][patreon-badge]][patreon-link]
 
 
-[travis-badge]: https://travis-ci.org/lihaoyi/cask.svg
-[travis-link]: https://travis-ci.org/lihaoyi/cask
-[gitter-badge]: https://badges.gitter.im/Join%20Chat.svg
-[gitter-link]: https://gitter.im/lihaoyi/cask?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+[discord-badge]: https://img.shields.io/badge/discord-join_chat-61AA8F.svg?logo=discord
+[discord-link]: https://discord.gg/scala
 [patreon-badge]: https://img.shields.io/badge/patreon-sponsor-ff69b4.svg
 [patreon-link]: https://www.patreon.com/lihaoyi
 


### PR DESCRIPTION
I've noticed that the badges could benefit from some polishing, as mentioned in #117.

1. The travis badge doesn't appear to work anymore.
2. I've noticed that the community is now on discord and that gitter has very low activity. 
I see that the #com-lihaoyi discord channel is pretty active.

I did manage to generate the docs using `./amm build.sc` with java 8, and here how the docs page looks now.

<img width="1286" alt="Screenshot 2024-01-28 at 23 53 11" src="https://github.com/com-lihaoyi/cask/assets/224201/2efedbba-34f9-4619-b771-b9b1a4e866f3">

I could also update the README of the project with the badge to discord.