### PR TITLE
[RFC] Allow overlap between static routes and wildcards

### DIFF
--- a/cask/src/cask/main/Main.scala
+++ b/cask/src/cask/main/Main.scala
@@ -106,7 +106,7 @@ object Main{
         .map(java.net.URLDecoder.decode(_, "UTF-8"))
         .toList
 
-      dispatchTrie.lookup(decodedSegments, Map()) match {
+      dispatchTrie.lookup(decodedSegments, Vector()) match {
         case None => Main.writeResponse(exchange, handleNotFound(Request(exchange, decodedSegments)))
         case Some((methodMap, routeBindings, remaining)) =>
           methodMap.get(effectiveMethod) match {

--- a/cask/test/src/test/cask/DispatchTrieTests.scala
+++ b/cask/test/src/test/cask/DispatchTrieTests.scala
@@ -11,9 +11,9 @@ object DispatchTrieTests extends TestSuite {
       )(Seq(_))
 
       assert(
-        x.lookup(List("hello"), Map()) == Some((1, Map(), Nil)),
-        x.lookup(List("hello", "world"), Map()) == None,
-        x.lookup(List("world"), Map()) == None
+        x.lookup(List("hello"), Vector()) == Some((1, Map(), Nil)),
+        x.lookup(List("hello", "world"), Vector()) == None,
+        x.lookup(List("world"), Vector()) == None
       )
     }
     "nested" - {
@@ -24,11 +24,11 @@ object DispatchTrieTests extends TestSuite {
         )
       )(Seq(_))
       assert(
-        x.lookup(List("hello", "world"), Map()) == Some((1, Map(), Nil)),
-        x.lookup(List("hello", "cow"), Map()) == Some((2, Map(), Nil)),
-        x.lookup(List("hello"), Map()) == None,
-        x.lookup(List("hello", "moo"), Map()) == None,
-        x.lookup(List("hello", "world", "moo"), Map()) == None
+        x.lookup(List("hello", "world"), Vector()) == Some((1, Map(), Nil)),
+        x.lookup(List("hello", "cow"), Vector()) == Some((2, Map(), Nil)),
+        x.lookup(List("hello"), Vector()) == None,
+        x.lookup(List("hello", "moo"), Vector()) == None,
+        x.lookup(List("hello", "world", "moo"), Vector()) == None
       )
     }
     "bindings" - {
@@ -36,11 +36,11 @@ object DispatchTrieTests extends TestSuite {
         Seq((Vector(":hello", ":world"), 1, false))
       )(Seq(_))
       assert(
-        x.lookup(List("hello", "world"), Map()) == Some((1, Map("hello" -> "hello", "world" -> "world"), Nil)),
-        x.lookup(List("world", "hello"), Map()) == Some((1, Map("hello" -> "world", "world" -> "hello"), Nil)),
+        x.lookup(List("hello", "world"), Vector()) == Some((1, Map("hello" -> "hello", "world" -> "world"), Nil)),
+        x.lookup(List("world", "hello"), Vector()) == Some((1, Map("hello" -> "world", "world" -> "hello"), Nil)),
 
-        x.lookup(List("hello", "world", "cow"), Map()) == None,
-        x.lookup(List("hello"), Map()) == None
+        x.lookup(List("hello", "world", "cow"), Vector()) == None,
+        x.lookup(List("hello"), Vector()) == None
       )
     }
 
@@ -50,35 +50,21 @@ object DispatchTrieTests extends TestSuite {
       )(Seq(_))
 
       assert(
-        x.lookup(List("hello", "world"), Map()) ==  Some((1,Map(), Seq("world"))),
-        x.lookup(List("hello", "world", "cow"), Map()) ==  Some((1,Map(), Seq("world", "cow"))),
-        x.lookup(List("hello"), Map()) == Some((1,Map(), Seq())),
-        x.lookup(List(), Map()) == None
+        x.lookup(List("hello", "world"), Vector()) ==  Some((1,Map(), Seq("world"))),
+        x.lookup(List("hello", "world", "cow"), Vector()) ==  Some((1,Map(), Seq("world", "cow"))),
+        x.lookup(List("hello"), Vector()) == Some((1,Map(), Seq())),
+        x.lookup(List(), Vector()) == None
       )
     }
 
-    "errors" - {
+    "wildcards" - {
       test - {
         DispatchTrie.construct(0,
           Seq(
             (Vector("hello", ":world"), 1, false),
-            (Vector("hello", "world"),  2, false)
+            (Vector("hello", "world"),  1, false)
           )
         )(Seq(_))
-
-        val ex = intercept[Exception]{
-          DispatchTrie.construct(0,
-            Seq(
-              (Vector("hello", ":world"), 1, false),
-              (Vector("hello", "world"),  1, false)
-            )
-          )(Seq(_))
-        }
-
-        assert(
-          ex.getMessage ==
-          "Routes overlap with wildcards: 1 /hello/:world, 1 /hello/world"
-        )
       }
       test - {
         DispatchTrie.construct(0,
@@ -87,21 +73,9 @@ object DispatchTrieTests extends TestSuite {
             (Vector("hello", "world", "omg"), 2, false)
           )
         )(Seq(_))
-
-        val ex = intercept[Exception]{
-          DispatchTrie.construct(0,
-            Seq(
-              (Vector("hello", ":world"), 1, false),
-              (Vector("hello", "world", "omg"), 1, false)
-            )
-          )(Seq(_))
-        }
-
-        assert(
-          ex.getMessage ==
-          "Routes overlap with wildcards: 1 /hello/:world, 1 /hello/world/omg"
-        )
       }
+    }
+    "errors" - {
       test - {
         DispatchTrie.construct(0,
           Seq(
@@ -143,7 +117,7 @@ object DispatchTrieTests extends TestSuite {
 
         assert(
           ex.getMessage ==
-          "Routes overlap with wildcards: 1 /hello/:world, 1 /hello/:cow"
+          "More than one endpoint has the same path: 1 /hello/:world, 1 /hello/:cow"
         )
       }
       test - {

--- a/example/queryParams/app/src/QueryParams.scala
+++ b/example/queryParams/app/src/QueryParams.scala
@@ -2,7 +2,7 @@ package app
 object QueryParams extends cask.MainRoutes{
 
   @cask.get("/article/:articleId") // Mandatory query param, e.g. HOST/article/foo?param=bar
-  def getArticle(articleId: Int, param: String) = { 
+  def getArticle(articleId: Int, param: String) = {
     s"Article $articleId $param"
   }
 
@@ -29,6 +29,21 @@ object QueryParams extends cask.MainRoutes{
   @cask.get("/user2/:userName") // allow unknown params, e.g. HOST/article/foo?foo=bar&qux=baz
   def getUserProfileAllowUnknown(userName: String, params: cask.QueryParams) = {
     s"User $userName " + params.value
+  }
+
+  @cask.get("/statics/foo")
+  def getStatic() = {
+    "static route takes precedence"
+  }
+
+  @cask.get("/statics/:foo")
+  def getDynamics(foo: String) = {
+    s"dynamic route $foo"
+  }
+
+  @cask.get("/statics/bar")
+  def getStatic2() = {
+    "another static route"
   }
 
   initialize()

--- a/example/queryParams/app/test/src/ExampleTests.scala
+++ b/example/queryParams/app/test/src/ExampleTests.scala
@@ -90,6 +90,16 @@ object ExampleTests extends TestSuite{
         res3 == "User lihaoyi Map(unknown1 -> WrappedArray(123), unknown2 -> WrappedArray(abc))" ||
         res3 == "User lihaoyi Map(unknown1 -> ArraySeq(123), unknown2 -> ArraySeq(abc))"
       )
+
+      assert(
+        requests.get(s"$host/statics/foo").text() == "static route takes precedence"
+      )
+      assert(
+        requests.get(s"$host/statics/hello").text() == "dynamic route hello"
+      )
+      assert(
+        requests.get(s"$host/statics/bar").text() == "another static route"
+      )
     }
   }
 }


### PR DESCRIPTION
This changes the DispatchTrie to allow overlapping wildcard segments in paths with static ones, with a preference for the latter.

For example, consider the following routes:

```
@cask.get("/settings")
def settings() = "settings"

@cask.get("/:id")
def user(id: String) = s"user $id"
```

This is currently not allowed. With these changes, it would be allowed, and the static route `settings` would be preferred, with a fallback to the dynamic route `user`:

```
GET /settings => settings
GET /foo => user foo
GET /bar => user bar
```

---

The reason I'm proposing this change is mostly for use in HTML applications (i.e. not RPC-style JSON APIs). In this scenario, short URLs are useful, since users may type them directly and associate meaning to them.

Consider for example the way GitHub structures URLs. If github were written with cask's current routing logic, it would not be possible to have URLs such as `/settings` and `/com-lihaoyi`, and instead some namespacing would need to be introduced (e.g. `/orgs/com-lihaoyi`) to separate these, which might not actually be relevant for users.

Of course, with these changes we will no longer catch developer errors that accidentally define wildcard-overlapping routes with non-wildcard ones. It will also be up to the application developer to make sure that there aren't any accidental overlaps between valid values of wildcards and static routes (e.g. in the example above, the application developer would somehow need to make sure that there isn't a user called "settings" in their system).

Given these drawbacks, I'd like to hear your thoughts on this in general. Personally I think that it's useful to enforce non-overlaps for API purposes, because this forces you to design a more robust url scheme. However, for HTML application purposes, I think that allowing shorter URLs is useful and probably outweighs the current limitations. Maybe we could also come up with a way to make this configurable.