### PR TITLE
Specify utf-8 as default form encoding in undertow helper

### DIFF
--- a/cask/src/cask/endpoints/FormEndpoint.scala
+++ b/cask/src/cask/endpoints/FormEndpoint.scala
@@ -55,7 +55,10 @@ class postForm(val path: String, override val subpath: Boolean = false)
   def wrapFunction(ctx: Request,
                        delegate: Delegate): Result[Response.Raw] = {
     try {
-      val formData = FormParserFactory.builder().build().createParser(ctx.exchange).parseBlocking()
+      val formData = FormParserFactory
+        .builder().withDefaultCharset("utf-8").build()
+        .createParser(ctx.exchange)
+        .parseBlocking()
       delegate(
         formData
           .iterator()


### PR DESCRIPTION
This makes it possible to parse non-ascii characters in form fields.