### PR TITLE
Rework compile time error message for scala 3

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -11,7 +11,7 @@ import de.tobiasroeser.mill.vcs.version.VcsVersion
 
 val scala213 = "2.13.10"
 val scala212 = "2.12.17"
-val scala3 = "3.2.2"
+val scala3 = "3.3.4"
 val scalaJS = "1.13.0"
 val communityBuildDottyVersion = sys.props.get("dottyVersion").toList
 

--- a/cask/src-3/cask/router/Macros.scala
+++ b/cask/src-3/cask/router/Macros.scala
@@ -163,7 +163,9 @@ object Macros {
       case iss: ImplicitSearchSuccess =>
         iss.tree.asExpr
       case isf: ImplicitSearchFailure =>
-        report.error(s"can't convert ${rtp.typeSymbol.fullName} to a response", method.pos.get)
+        def prettyPos(pos: Position) =
+          s"${pos.sourceFile}:${pos.startLine + 1}:${pos.startColumn + 1}"
+        report.error(s"error in route definition `def ${method.name}` (at ${prettyPos(method.pos.get)}): the method's return type ${rtp.show} cannot be converted to the expected response type ${innerReturnedTpt.show}", method.pos.get)
         '{???}
     }
 

--- a/cask/test/src-3/test/cask/FailureTests3.scala
+++ b/cask/test/src-3/test/cask/FailureTests3.scala
@@ -1,0 +1,19 @@
+package test.cask
+
+import cask.model.Request
+import utest._
+
+object FailureTests3 extends TestSuite {
+  val tests = Tests{
+    "returnType" - {
+      utest.compileError("""
+        object Routes extends cask.MainRoutes{
+          @cask.get("/foo")
+          def hello(world: String) = (1, 1)
+          initialize()
+        }
+      """).msg ==>
+        "error in route definition `def hello` (at tasty-reflect:4:15): the method's return type scala.Tuple2[scala.Int, scala.Int] cannot be converted to the expected response type cask.model.Response[cask.model.Response.Data]"
+    }
+  }
+}


### PR DESCRIPTION
This includes more information in the error message that is generated when a route declaration has an invalid return type.

It notably also includes the source position, as discussed in #141.