### PR TITLE
Include bound path segments in request

### DIFF
--- a/cask/src/cask/main/Main.scala
+++ b/cask/src/cask/main/Main.scala
@@ -107,18 +107,17 @@ object Main{
         .toList
 
       dispatchTrie.lookup(decodedSegments, Vector()) match {
-        case None => Main.writeResponse(exchange, handleNotFound(Request(exchange, decodedSegments)))
+        case None => Main.writeResponse(exchange, handleNotFound(Request(exchange, decodedSegments, Map())))
         case Some((methodMap, routeBindings, remaining)) =>
           methodMap.get(effectiveMethod) match {
-            case None => Main.writeResponse(exchange, handleMethodNotAllowed(Request(exchange, remaining)))
+            case None => Main.writeResponse(exchange, handleMethodNotAllowed(Request(exchange, remaining, routeBindings)))
             case Some((routes, metadata)) =>
-              val req = Request(exchange, remaining)
+              val req = Request(exchange, remaining, routeBindings)
               Decorator.invoke(
                 req,
                 metadata.endpoint,
                 metadata.entryPoint.asInstanceOf[EntryPoint[Routes, _]],
                 routes,
-                routeBindings,
                 (mainDecorators ++ routes.decorators ++ metadata.decorators).toList,
                 Nil,
                 Nil

--- a/cask/src/cask/model/Params.scala
+++ b/cask/src/cask/model/Params.scala
@@ -9,7 +9,7 @@ import io.undertow.server.handlers.CookieImpl
 case class QueryParams(value: Map[String, collection.Seq[String]])
 case class RemainingPathSegments(value: Seq[String])
 
-case class Request(exchange: HttpServerExchange, remainingPathSegments: Seq[String])
+case class Request(exchange: HttpServerExchange, remainingPathSegments: Seq[String], boundPathSegments: Map[String, String])
 extends geny.ByteData with geny.Readable {
   import collection.JavaConverters._
   lazy val cookies: Map[String, Cookie] = {

--- a/cask/src/cask/router/Decorators.scala
+++ b/cask/src/cask/router/Decorators.scala
@@ -37,7 +37,6 @@ object Decorator{
                 endpoint: Endpoint[_, _, _, _],
                 entryPoint: EntryPoint[T, _],
                 routes: T,
-                routeBindings: Map[String, String],
                 remainingDecorators: List[Decorator[_, _, _, _]],
                 inputContexts: List[Any],
                 bindings: List[Map[String, Any]]): Result[Any] = try {
@@ -45,14 +44,14 @@ object Decorator{
       case head :: rest =>
         head.asInstanceOf[Decorator[Any, Any, Any, Any]].wrapFunction(
           ctx,
-          (ictx, args) => invoke(ctx, endpoint, entryPoint, routes, routeBindings, rest, ictx :: inputContexts, args :: bindings)
+          (ictx, args) => invoke(ctx, endpoint, entryPoint, routes, rest, ictx :: inputContexts, args :: bindings)
             .asInstanceOf[Result[Nothing]]
         )
 
       case Nil =>
         endpoint.wrapFunction(ctx, { (ictx: Any, endpointBindings: Map[String, Any]) =>
 
-          val mergedEndpointBindings = endpointBindings ++ routeBindings.mapValues(endpoint.wrapPathSegment)
+          val mergedEndpointBindings = endpointBindings ++ ctx.boundPathSegments.mapValues(endpoint.wrapPathSegment)
           val finalBindings = mergedEndpointBindings :: bindings
 
           entryPoint


### PR DESCRIPTION
This makes it possible to access raw path parameters in a decorator.