### PR TITLE
Drop content-length header in compressed decorator

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -50,7 +50,7 @@ trait CaskMainModule extends CaskModule {
   object test extends ScalaTests with TestModule.Utest{
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0"
+      ivy"com.lihaoyi::requests::0.9.0"
     )
   }
   def moduleDeps = Seq(cask.util.jvm(crossScalaVersion))

--- a/cask/src/cask/decorators/compress.scala
+++ b/cask/src/cask/decorators/compress.scala
@@ -20,7 +20,9 @@ class compress extends cask.RawDecorator{
             wrap.flush()
             wrap.close()
           }
-          override def headers = v.data.headers
+          // Since we don't know the length of the gzipped data ahead of time,
+          // we drop the content length header.
+          override def headers = v.data.headers.filter(_._1 != "Content-Length")
         } -> Seq("Content-Encoding" -> "gzip")
       }else if (acceptEncodings.exists(_.toLowerCase == "deflate")){
         new Response.Data {
@@ -29,7 +31,9 @@ class compress extends cask.RawDecorator{
             v.data.write(wrap)
             wrap.flush()
           }
-          override def headers = v.data.headers
+          // Since we don't know the length of the compressed data ahead of
+          // time, we drop the content length header.
+          override def headers = v.data.headers.filter(_._1 != "Content-Length")
         } -> Seq("Content-Encoding" -> "deflate")
       }else v.data -> Nil
       Response(

--- a/example/compress/package.mill
+++ b/example/compress/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/compress2/package.mill
+++ b/example/compress2/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/compress3/package.mill
+++ b/example/compress3/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/cookies/package.mill
+++ b/example/cookies/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/decorated/package.mill
+++ b/example/decorated/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/decorated2/package.mill
+++ b/example/decorated2/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/decoratedContext/package.mill
+++ b/example/decoratedContext/package.mill
@@ -13,7 +13,7 @@ object app extends ScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/endpoints/package.mill
+++ b/example/endpoints/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/formJsonPost/package.mill
+++ b/example/formJsonPost/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0"
+      ivy"com.lihaoyi::requests::0.9.0"
     )
   }
 }

--- a/example/httpMethods/package.mill
+++ b/example/httpMethods/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
     def forkArgs = Seq("--add-opens=java.base/java.net=ALL-UNNAMED")
   }

--- a/example/minimalApplication/package.mill
+++ b/example/minimalApplication/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/minimalApplication2/package.mill
+++ b/example/minimalApplication2/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/queryParams/package.mill
+++ b/example/queryParams/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/redirectAbort/package.mill
+++ b/example/redirectAbort/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/scalatags/package.mill
+++ b/example/scalatags/package.mill
@@ -14,7 +14,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/staticFiles/package.mill
+++ b/example/staticFiles/package.mill
@@ -13,7 +13,7 @@ trait AppModule extends CrossScalaModule{ app =>
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
 
     def forkWorkingDir = app.millSourcePath

--- a/example/staticFiles2/package.mill
+++ b/example/staticFiles2/package.mill
@@ -13,7 +13,7 @@ trait AppModule extends CrossScalaModule{ app =>
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
 
     def forkWorkingDir = app.millSourcePath

--- a/example/todo/package.mill
+++ b/example/todo/package.mill
@@ -17,7 +17,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/todoApi/package.mill
+++ b/example/todoApi/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/todoDb/package.mill
+++ b/example/todoDb/package.mill
@@ -15,7 +15,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/twirl/package.mill
+++ b/example/twirl/package.mill
@@ -19,7 +19,7 @@ trait AppModule extends CrossScalaModule with mill.twirllib.TwirlModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/variableRoutes/package.mill
+++ b/example/variableRoutes/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
     )
   }
 }

--- a/example/websockets/package.mill
+++ b/example/websockets/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
       ivy"org.asynchttpclient:async-http-client:2.12.3"
     )
   }

--- a/example/websockets2/package.mill
+++ b/example/websockets2/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
       ivy"org.asynchttpclient:async-http-client:2.12.3"
     )
   }

--- a/example/websockets3/package.mill
+++ b/example/websockets3/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
       ivy"org.asynchttpclient:async-http-client:2.12.3"
     )
   }

--- a/example/websockets4/package.mill
+++ b/example/websockets4/package.mill
@@ -12,7 +12,7 @@ trait AppModule extends CrossScalaModule{
 
     def ivyDeps = Agg(
       ivy"com.lihaoyi::utest::0.8.4",
-      ivy"com.lihaoyi::requests::0.8.0",
+      ivy"com.lihaoyi::requests::0.9.0",
       ivy"org.asynchttpclient:async-http-client:2.12.3"
     )
   }


### PR DESCRIPTION
Since we're compressing data on the fly, we can't know the content-length ahead of time. While requests 0.8.0 (which uses the JDK's URLConnection) allowed this, requests 0.9.0 (which uses the new HttpClient API) is stricter and fails.

Also upgrade requests to 0.9.0