### PR TITLE
Upgrade scala patch versions to support jdk 21

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -9,10 +9,10 @@ import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.4.0`
 import $ivy.`com.github.lolgab::mill-mima::0.0.23`
 import de.tobiasroeser.mill.vcs.version.VcsVersion
 
-val scala213 = "2.13.10"
-val scala212 = "2.12.17"
+val scala213 = "2.13.15"
+val scala212 = "2.12.20"
 val scala3 = "3.3.4"
-val scalaJS = "1.13.0"
+val scalaJS = "1.17.0"
 val communityBuildDottyVersion = sys.props.get("dottyVersion").toList
 
 val scalaVersions = List(scala212, scala213, scala3) ++ communityBuildDottyVersion
@@ -43,9 +43,9 @@ trait CaskMainModule extends CaskModule {
     Agg.when(!isScala3)(ivy"org.scala-lang:scala-reflect:$crossScalaVersion")
   }
 
-  def compileIvyDeps = Agg.when(!isScala3)(ivy"com.lihaoyi:::acyclic:0.3.6")
+  def compileIvyDeps = Agg.when(!isScala3)(ivy"com.lihaoyi:::acyclic:0.3.15")
   def scalacOptions = Agg.when(!isScala3)("-P:acyclic:force").toSeq
-  def scalacPluginIvyDeps = Agg.when(!isScala3)(ivy"com.lihaoyi:::acyclic:0.3.6")
+  def scalacPluginIvyDeps = Agg.when(!isScala3)(ivy"com.lihaoyi:::acyclic:0.3.15")
 
   object test extends ScalaTests with TestModule.Utest{
     def ivyDeps = Agg(

--- a/example/twirl/package.mill
+++ b/example/twirl/package.mill
@@ -6,8 +6,8 @@ trait AppModule extends CrossScalaModule with mill.twirllib.TwirlModule{
 
   def moduleDeps = Seq(build.cask(crossScalaVersion))
 
-  def twirlScalaVersion = "2.13.10"
-  def twirlVersion = "1.5.1"
+  def twirlScalaVersion = "2.13.15"
+  def twirlVersion = "1.6.8"
 
   def generatedSources = T{ Seq(compileTwirl().classes) }
   def ivyDeps = Agg[Dep](


### PR DESCRIPTION
It appears that it actually wasn't twirl that was preventing a build under jdk 21. Upgrading the various scala patch versions seems to fix it.

I've tested this manually on my machine. In the future, it could be interesting to also include a CI workflow that uses jdk 21.

Fixes #153 

