### PR TITLE
Fix path traversal issue on static files

### DIFF
--- a/cask/src/cask/endpoints/StaticEndpoints.scala
+++ b/cask/src/cask/endpoints/StaticEndpoints.scala
@@ -5,7 +5,7 @@ import cask.model.Request
 object StaticUtil{
   def makePathAndContentType(t: String, ctx: Request) = {
     val leadingSlash = if (t.startsWith("/")) "/" else ""
-    val path = leadingSlash + (cask.internal.Util.splitPath(t) ++ ctx.remainingPathSegments)
+    val path = leadingSlash + (cask.internal.Util.splitPath(t) ++ ctx.remainingPathSegments.flatMap(cask.internal.Util.splitPath))
       .filter(s => s != "." && s != "..")
       .mkString("/")
     val contentType = java.nio.file.Files.probeContentType(java.nio.file.Paths.get(path))


### PR DESCRIPTION
I discovered that there is a path traversal vulnerability with static files. Here is a [repository](https://github.com/Maeeen/cask-static-path-traversal-issue) that showcases the issue.


In `StaticUtil` (`StaticEndpoints.scala`), the `ctx.remainingPathSegments` is not properly sanitized and is priorly decoded in `Main.scala`. Therefore, if a static endpoint has a remaining path segment having `/` (e.g. if a client sends a `static/..%2F/hi.txt`), `filter` will fail to filter the `..` and the path `static/../hi.txt` will be returned to get returned to the client, which should be prohibited.