### PR TITLE
feat: Add loom Support.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         java: [ '11', '17', '21' ]
-    name: Tests for Java ${{ matrix.Java }}
+    name: Tests local for Java ${{ matrix.Java }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup java
@@ -27,14 +27,18 @@ jobs:
       - name: Run tests
         run: |
           set -eux
-          ./mill -ikj1 --disable-ticker __.testLocal
+          if [ "${{ matrix.java }}" == "21" ]; then
+             JAVA_OPTS='--add-opens java.base/java.lang=ALL-UNNAMED -Dcask.virtual-threads.enabled=true' ./mill -ikj1 --disable-ticker __.testLocal
+          else
+            ./mill -ikj1 --disable-ticker __.testLocal
+          fi
 
   test-examples:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         java: [ '11', '17', '21' ]
-    name: Tests for Java ${{ matrix.Java }}
+    name: Tests examples for Java ${{ matrix.Java }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup java
@@ -45,8 +49,13 @@ jobs:
       - name: Run tests
         run: |
           set -eux
-          ./mill __.publishLocal
-          ./mill -ikj1 --disable-ticker testExamples
+            if [ "${{ matrix.java }}" == "21" ]; then
+                ./mill __.publishLocal
+                JAVA_OPTS='--add-opens java.base/java.lang=ALL-UNNAMED -Dcask.virtual-threads.enabled=true' ./mill -ikj1 --disable-ticker testExamples
+            else
+                ./mill __.publishLocal
+                ./mill -ikj1 --disable-ticker testExamples
+            fi
 
   publish-sonatype:
     if: github.repository == 'com-lihaoyi/cask' && contains(github.ref, 'refs/tags/')

--- a/build.mill
+++ b/build.mill
@@ -85,6 +85,89 @@ object cask extends Cross[CaskMainModule](scalaVersions) {
   }
 }
 
+trait BenchmarkModule extends CrossScalaModule {
+  def moduleDeps = Seq(cask(crossScalaVersion))
+  def ivyDeps = Agg[Dep](
+  )
+}
+
+object benchmark extends Cross[BenchmarkModule](build.scalaVersions) with RunModule {
+
+  def waitForServer(url: String, maxAttempts: Int = 120): Boolean = {
+    (1 to maxAttempts).exists { attempt =>
+      try {
+        Thread.sleep(3000)
+        println("Checking server... Attempt " + attempt)
+        os.proc("curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", url)
+          .call(check = false)
+          .exitCode == 0
+      } catch {
+        case _: Throwable =>
+          Thread.sleep(3000)
+          false
+      }
+    }
+  }
+
+  def runBenchMark(projectRoot: os.Path, example: String, vt: Boolean) = {
+    def runMillBackground(example: String, vt: Boolean) = {
+      println(s"Running $example with vt: $vt")
+      println("projectRoot: " + projectRoot)
+      os.proc(
+          "mill",
+          s"example.$example.app[$scala213].run")
+        .spawn(
+          cwd = projectRoot,
+          env = Map("CASK_VIRTUAL_THREAD" -> vt.toString),
+          stdout = os.Inherit,
+          stderr = os.Inherit)
+    }
+
+    val duration = "30s"
+    val threads = "4"
+    val connections = "100"
+    val url = "http://localhost:8080/"
+    val serverApp = runMillBackground(example, vt)
+
+    println(s"Waiting for server to start..., vt:$vt")
+    if (!waitForServer(url)) {
+      serverApp.destroy()
+      println("Failed to start server")
+      sys.exit(1)
+    }
+
+    val results = os.proc("wrk",
+      "-t", threads,
+      "-c", connections,
+      "-d", duration,
+      url
+    ).call(stderr = os.Pipe)
+    serverApp.destroyForcibly()
+    Thread.sleep(1000)
+
+    println(s"""\n$example result with ${if (vt) "(virtual threads)" else "(platform threads)"}:""")
+    println(results.out.text())
+  }
+
+  def runBenchmarks() = T.command {
+    val projectRoot = T.workspace
+    if (os.proc("which", "wrk").call(check = false).exitCode != 0) {
+      println("Error: wrk is not installed. Please install wrk first.")
+      sys.exit(1)
+    }
+    for (example <- Seq(
+      "staticFilesWithLoom",
+      "todoDbWithLoom",
+      "minimalApplicationWithLoom")) {
+      println(s"target server started, starting run benchmark with wrk for :$example with VT:false")
+      runBenchMark(projectRoot, example, vt = false)
+      println(s"target server started, starting run benchmark with wrk for :$example with VT:true")
+      runBenchMark(projectRoot, example, vt = true)
+    }
+
+  }
+}
+
 trait LocalModule extends CrossScalaModule{
   override def millSourcePath = super.millSourcePath / "app"
   def moduleDeps = Seq(cask(crossScalaVersion))
@@ -111,13 +194,16 @@ def zippedExamples = T {
     build.example.httpMethods.millSourcePath,
     build.example.minimalApplication.millSourcePath,
     build.example.minimalApplication2.millSourcePath,
+    build.example.minimalApplicationWithLoom.millSourcePath,
     build.example.redirectAbort.millSourcePath,
     build.example.scalatags.millSourcePath,
     build.example.staticFiles.millSourcePath,
+    build.example.staticFilesWithLoom.millSourcePath,
     build.example.staticFiles2.millSourcePath,
     build.example.todo.millSourcePath,
     build.example.todoApi.millSourcePath,
     build.example.todoDb.millSourcePath,
+    build.example.todoDbWithLoom.millSourcePath,
     build.example.twirl.millSourcePath,
     build.example.variableRoutes.millSourcePath,
     build.example.queryParams.millSourcePath,

--- a/cask/src/cask/internal/ThreadBlockingHandler.scala
+++ b/cask/src/cask/internal/ThreadBlockingHandler.scala
@@ -1,0 +1,18 @@
+package cask.internal
+
+import io.undertow.server.{HttpHandler, HttpServerExchange}
+
+import java.util.concurrent.Executor
+
+/**
+ * A handler that dispatches the request to the given handler using the given executor.
+ * */
+final class ThreadBlockingHandler(executor: Executor, handler: HttpHandler) extends HttpHandler {
+  require(executor ne null, "Executor should not be null")
+  require(handler ne null, "Handler should not be null")
+
+  def handleRequest(exchange: HttpServerExchange): Unit = {
+    exchange.startBlocking()
+    exchange.dispatch(executor, handler)
+  }
+}

--- a/cask/src/cask/internal/Util.scala
+++ b/cask/src/cask/internal/Util.scala
@@ -1,24 +1,121 @@
 package cask.internal
 
 import java.io.{InputStream, PrintWriter, StringWriter}
-
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable
 import java.io.OutputStream
-
+import java.lang.invoke.{MethodHandles, MethodType}
+import java.util.concurrent.{Executor, ExecutorService, ForkJoinPool, ThreadFactory}
 import scala.annotation.switch
 import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.Try
+import scala.util.control.NonFatal
 
 object Util {
+  private val lookup = MethodHandles.lookup()
+
+  import cask.util.Logger.Console.globalLogger
+
+  /**
+   * Create a virtual thread executor with the given executor as the scheduler.
+   * */
+  def createVirtualThreadExecutor(executor: Executor): Option[ExecutorService] = {
+    (for {
+      factory <- Try(createVirtualThreadFactory("cask-handler-executor", executor))
+      executor <- Try(createNewThreadPerTaskExecutor(factory))
+    } yield executor).toOption
+  }
+
+  /**
+   * Create a default cask virtual thread executor if possible.
+   * */
+  def createDefaultCaskVirtualThreadExecutor: Option[ExecutorService] = {
+    for {
+      scheduler <- getDefaultVirtualThreadScheduler
+      executor <- createVirtualThreadExecutor(scheduler)
+    } yield executor
+  }
+
+  /**
+   * Try to get the default virtual thread scheduler, or null if not supported.
+   * */
+  def getDefaultVirtualThreadScheduler: Option[ForkJoinPool] = {
+    try {
+      val virtualThreadClass = Class.forName("java.lang.VirtualThread")
+      val privateLookup = MethodHandles.privateLookupIn(virtualThreadClass, lookup)
+      val defaultSchedulerField = privateLookup.findStaticVarHandle(virtualThreadClass, "DEFAULT_SCHEDULER", classOf[ForkJoinPool])
+      Option(defaultSchedulerField.get().asInstanceOf[ForkJoinPool])
+    } catch {
+      case NonFatal(e) =>
+        //--add-opens java.base/java.lang=ALL-UNNAMED
+        globalLogger.exception(e)
+        None
+    }
+  }
+
+  def createNewThreadPerTaskExecutor(threadFactory: ThreadFactory): ExecutorService = {
+    try {
+      val executorsClazz = ClassLoader.getSystemClassLoader.loadClass("java.util.concurrent.Executors")
+      val newThreadPerTaskExecutorMethod = lookup.findStatic(
+        executorsClazz,
+        "newThreadPerTaskExecutor",
+        MethodType.methodType(classOf[ExecutorService], classOf[ThreadFactory]))
+      newThreadPerTaskExecutorMethod.invoke(threadFactory)
+        .asInstanceOf[ExecutorService]
+    } catch {
+      case NonFatal(e) =>
+        globalLogger.exception(e)
+        throw new UnsupportedOperationException("Failed to create newThreadPerTaskExecutor.", e)
+    }
+  }
+
+  /**
+   * Create a virtual thread factory with a executor, the executor will be used as the scheduler of
+   * virtual thread.
+   *
+   * The executor should run task on platform threads.
+   *
+   * returns null if not supported.
+   */
+  def createVirtualThreadFactory(prefix: String,
+                                 executor: Executor): ThreadFactory =
+    try {
+      val builderClass = ClassLoader.getSystemClassLoader.loadClass("java.lang.Thread$Builder")
+      val ofVirtualClass = ClassLoader.getSystemClassLoader.loadClass("java.lang.Thread$Builder$OfVirtual")
+      val ofVirtualMethod = lookup.findStatic(classOf[Thread], "ofVirtual", MethodType.methodType(ofVirtualClass))
+      var builder = ofVirtualMethod.invoke()
+      if (executor != null) {
+        val clazz = builder.getClass
+        val privateLookup = MethodHandles.privateLookupIn(
+          clazz,
+          lookup
+        )
+        val schedulerFieldSetter = privateLookup
+          .findSetter(clazz, "scheduler", classOf[Executor])
+        schedulerFieldSetter.invoke(builder, executor)
+      }
+      val nameMethod = lookup.findVirtual(ofVirtualClass, "name",
+        MethodType.methodType(ofVirtualClass, classOf[String], classOf[Long]))
+      val factoryMethod = lookup.findVirtual(builderClass, "factory", MethodType.methodType(classOf[ThreadFactory]))
+      builder = nameMethod.invoke(builder, prefix + "-virtual-thread-", 0L)
+      factoryMethod.invoke(builder).asInstanceOf[ThreadFactory]
+    } catch {
+      case NonFatal(e) =>
+        globalLogger.exception(e)
+        //--add-opens java.base/java.lang=ALL-UNNAMED
+        throw new UnsupportedOperationException("Failed to create virtual thread factory.", e)
+    }
+
   def firstFutureOf[T](futures: Seq[Future[T]])(implicit ec: ExecutionContext) = {
     val p = Promise[T]
     futures.foreach(_.foreach(p.trySuccess))
     p.future
   }
+
   /**
-    * Convert a string to a C&P-able literal. Basically
-    * copied verbatim from the uPickle source code.
-    */
+   * Convert a string to a C&P-able literal. Basically
+   * copied verbatim from the uPickle source code.
+   */
   def literalize(s: IndexedSeq[Char], unicode: Boolean = true) = {
     val sb = new StringBuilder
     sb.append('"')
@@ -47,8 +144,8 @@ object Util {
   def transferTo(in: InputStream, out: OutputStream) = {
     val buffer = new Array[Byte](8192)
 
-    while ({
-      in.read(buffer) match{
+    while ( {
+      in.read(buffer) match {
         case -1 => false
         case n =>
           out.write(buffer, 0, n)
@@ -56,20 +153,21 @@ object Util {
       }
     }) ()
   }
+
   def pluralize(s: String, n: Int) = {
     if (n == 1) s else s + "s"
   }
 
   /**
-    * Splits a string into path segments; automatically removes all
-    * leading/trailing slashes, and ignores empty path segments.
-    *
-    * Written imperatively for performance since it's used all over the place.
-    */
+   * Splits a string into path segments; automatically removes all
+   * leading/trailing slashes, and ignores empty path segments.
+   *
+   * Written imperatively for performance since it's used all over the place.
+   */
   def splitPath(p: String): collection.IndexedSeq[String] = {
     val pLength = p.length
     var i = 0
-    while(i < pLength && p(i) == '/') i += 1
+    while (i < pLength && p(i) == '/') i += 1
     var segmentStart = i
     val out = mutable.ArrayBuffer.empty[String]
 
@@ -81,7 +179,7 @@ object Util {
       segmentStart = i + 1
     }
 
-    while(i < pLength){
+    while (i < pLength) {
       if (p(i) == '/') complete()
       i += 1
     }
@@ -96,6 +194,7 @@ object Util {
     pw.flush()
     trace.toString
   }
+
   def softWrap(s: String, leftOffset: Int, maxWidth: Int) = {
     val oneLine = s.linesIterator.mkString(" ").split(' ')
 
@@ -103,13 +202,13 @@ object Util {
 
     val output = new StringBuilder(oneLine.head)
     var currentLineWidth = oneLine.head.length
-    for(chunk <- oneLine.tail){
+    for (chunk <- oneLine.tail) {
       val addedWidth = currentLineWidth + chunk.length + 1
-      if (addedWidth > maxWidth){
+      if (addedWidth > maxWidth) {
         output.append("\n" + indent)
         output.append(chunk)
         currentLineWidth = chunk.length
-      } else{
+      } else {
         currentLineWidth = addedWidth
         output.append(' ')
         output.append(chunk)
@@ -117,12 +216,13 @@ object Util {
     }
     output.mkString
   }
+
   def sequenceEither[A, B, M[X] <: TraversableOnce[X]](in: M[Either[A, B]])(
     implicit cbf: CanBuildFrom[M[Either[A, B]], B, M[B]]): Either[A, M[B]] = {
     in.foldLeft[Either[A, mutable.Builder[B, M[B]]]](Right(cbf(in))) {
-      case (acc, el) =>
-        for (a <- acc; e <- el) yield a += e
-    }
+        case (acc, el) =>
+          for (a <- acc; e <- el) yield a += e
+      }
       .map(_.result())
   }
 }

--- a/docs/pages/1 - Cask - a Scala HTTP micro-framework.md
+++ b/docs/pages/1 - Cask - a Scala HTTP micro-framework.md
@@ -479,7 +479,7 @@ Cask can support using Virtual Threads to handle the request out of the box, you
 
 **NOTE**: 
 1. If your code is CPU-bound, you should not use virtual threads, because it will not improve the performance, but will increase the overhead.
-2. A common deadlock can happen when both a virtual thread and a platform thread try to load the same class, but there is no carrier thread available to execute the virtual thread, which will lead to a deadlock, make sure `jdk.unparker.maxPoolSize` is large enough to avoid it.
+2. A common deadlock can happen when both a virtual thread and a platform thread try to load the same class, but there is no carrier thread available to execute the virtual thread, which will lead to a deadlock, make sure `jdk.virtualThreadScheduler.maxPoolSize` is large enough to avoid it.
 3. Virtual thread does some kind of `rescheduling` which may lead to higher latency when the task is actually cpu bound.
 4. OOM is a common issue when you have many virtual threads, you should limit the max in-flight requests to avoid it.
 5. There are some known issues which can leads to a deadlock, you should be careful when using it in production, at least after long time stress test. 

--- a/example/minimalApplicationWithLoom/app/src/MinimalApplicationWithLoom.scala
+++ b/example/minimalApplicationWithLoom/app/src/MinimalApplicationWithLoom.scala
@@ -1,0 +1,55 @@
+package app
+
+import cask.main.Main
+
+import java.lang.management.{ManagementFactory, RuntimeMXBean}
+import java.util.concurrent.{ExecutorService, Executors}
+
+// run benchmark with : ./mill benchmark.runBenchmark
+object MinimalApplicationWithLoom extends cask.MainRoutes {
+  // Print Java version
+  private val javaVersion: String = System.getProperty("java.version")
+  println("Java Version: " + javaVersion)
+
+  // Print JVM arguments// Print JVM arguments
+  private val runtimeMxBean: RuntimeMXBean = ManagementFactory.getRuntimeMXBean
+  private val jvmArguments = runtimeMxBean.getInputArguments
+  println("JVM Arguments:")
+
+  jvmArguments.forEach((arg: String) => println(arg))
+
+  println(Main.VIRTUAL_THREAD_ENABLED + " :" + System.getProperty(Main.VIRTUAL_THREAD_ENABLED))
+
+  //Use the same underlying executor for both virtual and non-virtual threads
+  private val executor = Executors.newFixedThreadPool(4)
+
+  //TO USE LOOM:
+  //1. JDK 21 or later is needed.
+  //2. add VM option: --add-opens java.base/java.lang=ALL-UNNAMED
+  //3. set system property: cask.virtual-threads.enabled=true
+  //4. NOTE: `java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor` is using the shared
+  //   ForkJoinPool in VirtualThread. If you want to use a separate ForkJoinPool, you can create
+  //   a new ForkJoinPool instance and pass it to `createVirtualThreadExecutor` method.
+
+  override protected def handlerExecutor(): Option[ExecutorService] = {
+    super.handlerExecutor().orElse(Some(executor))
+  }
+
+  /**
+   * With curl: curl -X GET http://localhost:8080/
+   * you wil see something like:
+   * Hello World! from thread:VirtualThread[#63,cask-handler-executor-virtual-thread-10]/runnable@ForkJoinPool-1-worker-1%
+   * */
+  @cask.get("/")
+  def hello() = {
+    Thread.sleep(100) // simulate some blocking work
+    "Hello World!"
+  }
+
+  @cask.post("/do-thing")
+  def doThing(request: cask.Request) = {
+    request.text().reverse
+  }
+
+  initialize()
+}

--- a/example/minimalApplicationWithLoom/app/test/src/ExampleTests.scala
+++ b/example/minimalApplicationWithLoom/app/test/src/ExampleTests.scala
@@ -1,0 +1,34 @@
+package app
+import io.undertow.Undertow
+import org.xnio.Options
+import utest._
+
+object ExampleTests extends TestSuite{
+  def withServer[T](example: cask.main.Main)(f: String => T): T = {
+    val server = Undertow.builder
+      .addHttpListener(8081, "localhost")
+      .setSocketOption(Options.REUSE_ADDRESSES, java.lang.Boolean.TRUE)
+      .setHandler(example.defaultHandler)
+      .build
+    server.start()
+    val res =
+      try f("http://localhost:8081")
+      finally server.stop()
+    res
+  }
+
+  val tests = Tests {
+    test("MinimalApplicationWithLoom") - withServer(MinimalApplicationWithLoom) { host =>
+      val success = requests.get(host)
+
+      success.text() ==> "Hello World!"
+      success.statusCode ==> 200
+
+      requests.get(s"$host/doesnt-exist", check = false).statusCode ==> 404
+
+      requests.post(s"$host/do-thing", data = "hello").text() ==> "olleh"
+
+      requests.delete(s"$host/do-thing", check = false).statusCode ==> 405
+    }
+  }
+}

--- a/example/minimalApplicationWithLoom/package.mill
+++ b/example/minimalApplicationWithLoom/package.mill
@@ -1,0 +1,47 @@
+package build.example.minimalApplicationWithLoom
+
+import mill._, scalalib._
+import mill.define.ModuleRef
+
+object app extends Cross[AppModule](build.scalaVersions)
+trait AppModule extends CrossScalaModule{
+
+  private def parseJvmArgs(argsStr: String) = {
+    argsStr.split(" ").filter(_.nonEmpty).toSeq
+  }
+
+  def forkArgs = Task.Input {
+    //TODO not sure why the env passing is not working
+    val envVirtualThread: String = T.env.getOrElse("CASK_VIRTUAL_THREAD", "false")
+    println("envVirtualThread: " + envVirtualThread)
+
+    val systemProps = Seq(s"-Dcask.virtual-threads.enabled=$envVirtualThread")
+
+    val baseArgs = Seq(
+      "--add-opens", "java.base/java.lang=ALL-UNNAMED"
+    )
+
+    val seq = baseArgs ++ systemProps
+    println("final forkArgs: " + seq)
+    seq
+  }
+
+  def zincWorker = ModuleRef(ZincWorkerJava11Latest)
+
+  def moduleDeps = Seq(build.cask(crossScalaVersion))
+
+  def ivyDeps = Agg[Dep](
+  )
+
+  object test extends ScalaTests with TestModule.Utest {
+    def ivyDeps = Agg(
+      ivy"com.lihaoyi::utest::0.8.4",
+      ivy"com.lihaoyi::requests::0.9.0",
+    )
+  }
+}
+
+object ZincWorkerJava11Latest extends ZincWorkerModule with CoursierModule {
+  def jvmId = "temurin:23.0.1"
+  def jvmIndexVersion = "latest.release"
+}

--- a/example/staticFiles/package.mill
+++ b/example/staticFiles/package.mill
@@ -22,7 +22,7 @@ trait AppModule extends CrossScalaModule{ app =>
 
     // redirect this to the forked `test` to make sure static file serving works
     def testLocal(args: String*) = T.command{
-      test(args:_*)
+      this.test(args:_*)
     }
   }
 }

--- a/example/staticFiles2/package.mill
+++ b/example/staticFiles2/package.mill
@@ -22,7 +22,7 @@ trait AppModule extends CrossScalaModule{ app =>
 
     // redirect this to the forked `test` to make sure static file serving works
     def testLocal(args: String*) = T.command{
-      test(args:_*)
+      this.test(args:_*)
     }
   }
 }

--- a/example/staticFilesWithLoom/app/resources/cask/example.txt
+++ b/example/staticFilesWithLoom/app/resources/cask/example.txt
@@ -1,0 +1,1 @@
+the quick brown fox jumps over the lazy dog

--- a/example/staticFilesWithLoom/app/src/StaticFilesWithLoom.scala
+++ b/example/staticFilesWithLoom/app/src/StaticFilesWithLoom.scala
@@ -1,0 +1,29 @@
+package app
+
+import cask.internal.Util
+
+import java.util.concurrent.{ExecutorService, Executors}
+
+object StaticFilesWithLoom extends cask.MainRoutes{
+  private val executor = Executors.newFixedThreadPool(4)
+
+  override protected def handlerExecutor(): Option[ExecutorService] = {
+    super.handlerExecutor().orElse(Some(executor))
+  }
+  
+  @cask.get("/")
+  def index() = {
+    "Hello!"
+  }
+
+  @cask.staticFiles("/static/file")
+  def staticFileRoutes() = "resources/cask"
+
+  @cask.staticResources("/static/resource")
+  def staticResourceRoutes() = "cask"
+
+  @cask.staticResources("/static/resource2")
+  def staticResourceRoutes2() = "."
+
+  initialize()
+}

--- a/example/staticFilesWithLoom/app/test/src/ExampleTests.scala
+++ b/example/staticFilesWithLoom/app/test/src/ExampleTests.scala
@@ -1,0 +1,35 @@
+package app
+import io.undertow.Undertow
+
+import utest._
+
+object ExampleTests extends TestSuite{
+  def withServer[T](example: cask.main.Main)(f: String => T): T = {
+    val server = Undertow.builder
+      .addHttpListener(8081, "localhost")
+      .setHandler(example.defaultHandler)
+      .build
+    server.start()
+    val res =
+      try f("http://localhost:8081")
+      finally server.stop()
+    res
+  }
+
+  val tests = Tests{
+
+    test("StaticFiles") - withServer(StaticFilesWithLoom){ host =>
+      requests.get(s"$host/static/file/example.txt").text() ==>
+        "the quick brown fox jumps over the lazy dog"
+
+      requests.get(s"$host/static/resource/example.txt").text() ==>
+        "the quick brown fox jumps over the lazy dog"
+
+      requests.get(s"$host/static/resource2/cask/example.txt").text() ==>
+        "the quick brown fox jumps over the lazy dog"
+
+      requests.get(s"$host/static/file/../../../build.sc", check = false).statusCode ==> 404
+    }
+
+  }
+}

--- a/example/staticFilesWithLoom/package.mill
+++ b/example/staticFilesWithLoom/package.mill
@@ -1,0 +1,58 @@
+package build.example.staticFilesWithLoom
+import mill._, scalalib._
+import mill.define.ModuleRef
+
+object app extends Cross[AppModule](build.scalaVersions)
+trait AppModule extends CrossScalaModule{ app =>
+
+  def moduleDeps = Seq(build.cask(crossScalaVersion))
+
+  def forkWorkingDir = app.millSourcePath
+  def ivyDeps = Agg[Dep](
+  )
+
+  private def parseJvmArgs(argsStr: String) = {
+    argsStr.split(" ").filter(_.nonEmpty).toSeq
+  }
+
+  def forkArgs = Task.Input {
+    //TODO not sure why the env passing is not working
+    val envVirtualThread: String = T.env.getOrElse("CASK_VIRTUAL_THREAD", "false")
+    println("envVirtualThread: " + envVirtualThread)
+
+    val systemProps = Seq(s"-Dcask.virtual-threads.enabled=$envVirtualThread")
+
+    val baseArgs = Seq(
+      "--add-opens", "java.base/java.lang=ALL-UNNAMED"
+    )
+
+    val seq = baseArgs ++ systemProps
+    println("final forkArgs: " + seq)
+    seq
+  }
+
+  def zincWorker = ModuleRef(ZincWorkerJava11Latest)
+
+  object test extends ScalaTests with TestModule.Utest{
+
+    def ivyDeps = Agg(
+      ivy"com.lihaoyi::utest::0.8.4",
+      ivy"com.lihaoyi::requests::0.9.0",
+    )
+
+    def forkWorkingDir = app.millSourcePath
+
+    def testSandboxWorkingDir = false
+
+    // redirect this to the forked `test` to make sure static file serving works
+    def testLocal(args: String*) = T.command{
+      this.test(args:_*)
+    }
+  }
+}
+
+
+object ZincWorkerJava11Latest extends ZincWorkerModule with CoursierModule {
+  def jvmId = "temurin:23.0.1"
+  def jvmIndexVersion = "latest.release"
+}

--- a/example/todoDbWithLoom/app/src/TodoMvcDbWithLoom.scala
+++ b/example/todoDbWithLoom/app/src/TodoMvcDbWithLoom.scala
@@ -1,0 +1,89 @@
+package app
+import scalasql.DbApi.Txn
+import scalasql.Sc
+import scalasql.SqliteDialect._
+
+import java.util.concurrent.{ExecutorService, Executors}
+
+object TodoMvcDbWithLoom extends cask.MainRoutes {
+  val tmpDb = java.nio.file.Files.createTempDirectory("todo-cask-sqlite")
+  val sqliteDataSource = new org.sqlite.SQLiteDataSource()
+  sqliteDataSource.setUrl(s"jdbc:sqlite:$tmpDb/file.db")
+  lazy val sqliteClient = new scalasql.DbClient.DataSource(
+    sqliteDataSource,
+    config = new scalasql.Config {}
+  )
+
+  private val executor = Executors.newFixedThreadPool(4)
+  override protected def handlerExecutor(): Option[ExecutorService] = {
+    super.handlerExecutor().orElse(Some(executor))
+  }
+
+  class transactional extends cask.RawDecorator{
+    def wrapFunction(pctx: cask.Request, delegate: Delegate) = {
+      sqliteClient.transaction { txn =>
+        val res = delegate(pctx, Map("txn" -> txn))
+        if (res.isInstanceOf[cask.router.Result.Error]) txn.rollback()
+        res
+      }
+    }
+  }
+
+  case class Todo[T[_]](id: T[Int], checked: T[Boolean], text: T[String])
+  object Todo extends scalasql.Table[Todo]{
+    implicit def todoRW = upickle.default.macroRW[Todo[Sc]]
+  }
+
+  sqliteClient.getAutoCommitClientConnection.updateRaw(
+    """CREATE TABLE todo (
+      |  id INTEGER PRIMARY KEY AUTOINCREMENT,
+      |  checked BOOLEAN,
+      |  text TEXT
+      |);
+      |
+      |INSERT INTO todo (checked, text) VALUES
+      |(1, 'Get started with Cask'),
+      |(0, 'Profit!');
+      |""".stripMargin
+  )
+
+  @transactional
+  @cask.get("/list/:state")
+  def list(state: String)(txn: Txn) = {
+    val filteredTodos = state match{
+      case "all" => txn.run(Todo.select)
+      case "active" => txn.run(Todo.select.filter(!_.checked))
+      case "completed" => txn.run(Todo.select.filter(_.checked))
+    }
+    upickle.default.write(filteredTodos)
+  }
+
+  @transactional
+  @cask.post("/add")
+  def add(request: cask.Request)(txn: Txn) = {
+    val body = request.text()
+    txn.run(
+      Todo
+        .insert
+        .columns(_.checked := false, _.text := body)
+        .returning(_.id)
+        .single
+    )
+
+    if (body == "FORCE FAILURE") throw new Exception("FORCE FAILURE BODY")
+  }
+
+  @transactional
+  @cask.post("/toggle/:index")
+  def toggle(index: Int)(txn: Txn) = {
+    txn.run(Todo.update(_.id === index).set(p => p.checked := !p.checked))
+  }
+
+  @transactional
+  @cask.post("/delete/:index")
+  def delete(index: Int)(txn: Txn) = {
+    txn.run(Todo.delete(_.id === index))
+  }
+
+  initialize()
+}

--- a/example/todoDbWithLoom/app/test/src/ExampleTests.scala
+++ b/example/todoDbWithLoom/app/test/src/ExampleTests.scala
@@ -1,0 +1,50 @@
+package app
+import io.undertow.Undertow
+
+import utest._
+
+object ExampleTests extends TestSuite{
+  def withServer[T](example: cask.main.Main)(f: String => T): T = {
+    val server = Undertow.builder
+      .addHttpListener(8081, "localhost")
+      .setHandler(example.defaultHandler)
+      .build
+    server.start()
+    val res =
+      try f("http://localhost:8081")
+      finally server.stop()
+    res
+  }
+
+  val tests = Tests{
+    test("TodoMvcDb") - withServer(TodoMvcDbWithLoom){ host =>
+      requests.get(s"$host/list/all").text() ==>
+        """[{"id":1,"checked":true,"text":"Get started with Cask"},{"id":2,"checked":false,"text":"Profit!"}]"""
+      requests.get(s"$host/list/active").text() ==>
+        """[{"id":2,"checked":false,"text":"Profit!"}]"""
+      requests.get(s"$host/list/completed").text() ==>
+        """[{"id":1,"checked":true,"text":"Get started with Cask"}]"""
+
+      requests.post(s"$host/toggle/2")
+
+      requests.get(s"$host/list/all").text() ==>
+        """[{"id":1,"checked":true,"text":"Get started with Cask"},{"id":2,"checked":true,"text":"Profit!"}]"""
+
+      requests.get(s"$host/list/active").text() ==>
+        """[]"""
+
+      requests.post(s"$host/add", data = "new Task")
+
+      // Make sure endpoint failures do not commit their transaction
+      requests.post(s"$host/add", data = "FORCE FAILURE", check = false).statusCode ==> 500
+
+      requests.get(s"$host/list/active").text() ==>
+        """[{"id":3,"checked":false,"text":"new Task"}]"""
+
+      requests.post(s"$host/delete/3")
+
+      requests.get(s"$host/list/active").text() ==>
+        """[]"""
+    }
+  }
+}

--- a/example/todoDbWithLoom/package.mill
+++ b/example/todoDbWithLoom/package.mill
@@ -1,0 +1,48 @@
+package build.example.todoDbWithLoom
+import mill._, scalalib._
+import mill.define.ModuleRef
+
+object app extends Cross[AppModule](build.scala213)
+trait AppModule extends CrossScalaModule{
+
+  private def parseJvmArgs(argsStr: String) = {
+    argsStr.split(" ").filter(_.nonEmpty).toSeq
+  }
+
+  def forkArgs = Task.Input {
+    //TODO not sure why the env passing is not working
+    val envVirtualThread: String = T.env.getOrElse("CASK_VIRTUAL_THREAD", "false")
+    println("envVirtualThread: " + envVirtualThread)
+
+    val systemProps = Seq(s"-Dcask.virtual-threads.enabled=$envVirtualThread")
+
+    val baseArgs = Seq(
+      "--add-opens", "java.base/java.lang=ALL-UNNAMED"
+    )
+
+    val seq = baseArgs ++ systemProps
+    println("final forkArgs: " + seq)
+    seq
+  }
+
+  def zincWorker = ModuleRef(ZincWorkerJava11Latest)
+
+  def moduleDeps = Seq(build.cask(crossScalaVersion))
+
+  def ivyDeps = Agg[Dep](
+    ivy"org.xerial:sqlite-jdbc:3.42.0.0",
+    ivy"com.lihaoyi::scalasql:0.1.0",
+  )
+
+  object test extends ScalaTests with TestModule.Utest {
+    def ivyDeps = Agg(
+      ivy"com.lihaoyi::utest::0.8.4",
+      ivy"com.lihaoyi::requests::0.9.0",
+    )
+  }
+}
+
+object ZincWorkerJava11Latest extends ZincWorkerModule with CoursierModule {
+  def jvmId = "temurin:23.0.1"
+  def jvmIndexVersion = "latest.release"
+}


### PR DESCRIPTION
Motivation:
Add Loom support.
refs: https://github.com/com-lihaoyi/cask/issues/90 , again 

Modification:
1. add `handlerExecutor()` and some helper methods for virtual threads.
2. some documents.

Result:
Virtual threads supported.

`wrk` is needed to run the benchmark

- miniAppWithSleep 100ms : ↑2300%
- todoDb:           ~↓6%
- staticFiles:      ~↓6%

```shell
./mill --no-build-lock benchmark.runBenchmarks
```

Results of same 4 Carrier/Platform threads:

```scala
[1] staticFilesWithLoom result with (platform threads):
[1] Running 30s test @ http://localhost:8080/
[1]   4 threads and 100 connections
[1]   Thread Stats   Avg      Stdev     Max   +/- Stdev
[1]     Latency     1.23ms  436.88us  28.64ms   98.91%
[1]     Req/Sec    20.54k     1.08k   22.69k    93.44%
[1]   2461250 requests in 30.10s, 342.70MB read
[1] Requests/sec:  81766.27
[1] Transfer/sec:     11.38MB
[1] 
[1] staticFilesWithLoom result with (virtual threads):
[1] Running 30s test @ http://localhost:8080/
[1]   4 threads and 100 connections
[1]   Thread Stats   Avg      Stdev     Max   +/- Stdev
[1]     Latency     4.41ms   14.69ms 157.91ms   95.15%
[1]     Req/Sec    19.00k     4.29k   22.09k    88.63%
[1]   2266289 requests in 30.02s, 315.55MB read
[1] Requests/sec:  75488.32
[1] Transfer/sec:     10.51MB
[1] 
[1] todoDbWithLoom result with (platform threads):
[1] Running 30s test @ http://localhost:8080/
[1]   4 threads and 100 connections
[1]   Thread Stats   Avg      Stdev     Max   +/- Stdev
[1]     Latency     1.22ms  172.42us  11.67ms   96.46%
[1]     Req/Sec    20.62k     1.29k   42.72k    93.01%
[1]   2466143 requests in 30.10s, 395.12MB read
[1]   Non-2xx or 3xx responses: 2466143
[1] Requests/sec:  81929.40
[1] Transfer/sec:     13.13MB
[1] 
[1] todoDbWithLoom result with (virtual threads):
[1] Running 30s test @ http://localhost:8080/
[1]   4 threads and 100 connections
[1]   Thread Stats   Avg      Stdev     Max   +/- Stdev
[1]     Latency     3.97ms   13.20ms 160.29ms   95.28%
[1]     Req/Sec    19.21k     3.68k   22.32k    89.41%
[1]   2284539 requests in 30.03s, 366.02MB read
[1]   Non-2xx or 3xx responses: 2284539
[1] Requests/sec:  76072.80
[1] Transfer/sec:     12.19MB
[1] 
[1] minimalApplicationWithLoom result with (platform threads):
[1] Running 30s test @ http://localhost:8080/
[1]   4 threads and 100 connections
[1]   Thread Stats   Avg      Stdev     Max   +/- Stdev
[1]     Latency     1.05s   575.57ms   1.99s    57.89%
[1]     Req/Sec    10.05      3.94    30.00     81.66%
[1]   1152 requests in 30.03s, 172.12KB read
[1]   Socket errors: connect 0, read 0, write 0, timeout 1076
[1] Requests/sec:     38.36
[1] Transfer/sec:      5.73KB
[1] 
[1] 
[1] minimalApplicationWithLoom result with (virtual threads):
[1] Running 30s test @ http://localhost:8080/
[1]   4 threads and 100 connections
[1]   Thread Stats   Avg      Stdev     Max   +/- Stdev
[1]     Latency   106.11ms    2.74ms 126.59ms   77.47%
[1]     Req/Sec   239.19     36.74   252.00     92.68%
[1]   28100 requests in 30.03s, 4.10MB read
[1] Requests/sec:    935.74
[1] Transfer/sec:    139.81KB



```



Some design choices:
1.  Using MethodHandle/Reflect to make it compile on Java 8 too.
2. Using MethodHandle to name the virtual threads that are needed, JPMS code can be added to open the can by default, but that is a little over-killed, so better with an explicitly `--add-opens java.base/java.lang=ALL-UNNAMED`
3. Add a virtualize or screen method to create a virtual thread executor from a **platform** thread pool, this is useful, especially if you want to limit the underlying queue size, FJP is unbounded.
4. Users can override the `handleExecutor` directly too.
