### PR TITLE
chore: add a helper method to create a dedicated virtual thread scheduler.

### DIFF
--- a/docs/pages/1 - Cask - a Scala HTTP micro-framework.md
+++ b/docs/pages/1 - Cask - a Scala HTTP micro-framework.md
@@ -477,6 +477,7 @@ Cask can support using Virtual Threads to handle the request out of the box, you
 1. You can change the default scheduler of the carrier threads with `cask.internal.Util.createVirtualThreadExecutor` method, but keep in mind, that's not officially supported by JDK for now.
 2. You can supply your own `Executor` by override the `handlerExecutor()` method in your `cask.Main` object, which will be called only once when the server starts.
 3. You can use `jdk.internal.misc.Blocker`'s `begin` and `end` methods to help the `ForkJoinPool` when needed.
+4. You can use `Util.createVirtualThreadScheduler` to create separate `ForkJoinPool` as scheduler for the virtual threads.
 
 **NOTE**: 
 


### PR DESCRIPTION
Motivation: 
Add a helper method to create a separate virtual thread scheduler.
